### PR TITLE
[FIX] Remove redunant joining messages by eva

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,7 @@ Install npm package:
 
     apt-get install npm
 
-NOTE: If you are behind a proxy, please run the following commands to set proxy for npm:<br/>
-
-    npm config set proxy http://<username>:<password>@<proxy-server-url>:<port>
-    npm config set https-proxy http://<username>:<password>@<proxy-server-url>:<port>
+NOTE: If you are behind institute proxy, please follow commands listed [here](https://wiki.metakgp.org/w/Institute_proxies#npm).
 
 Now you can start Eva locally by running:
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,16 @@ You can test your hubot by running the following, however some plugins will not
 behave as expected unless the [environment variables](#configuration) they rely
 upon have been set.
 
-You can start Eva locally by running:
+Install npm package:
+
+    apt-get install npm
+
+NOTE: If you are behind a proxy, please run the following commands to set proxy for npm:<br/>
+
+    npm config set proxy http://<username>:<password>@<proxy-server-url>:<port>
+    npm config set https-proxy http://<username>:<password>@<proxy-server-url>:<port>
+
+Now you can start Eva locally by running:
 
     % bin/hubot
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,34 @@ You can test your hubot by running the following, however some plugins will not
 behave as expected unless the [environment variables](#configuration) they rely
 upon have been set.
 
-Install npm package:
+#### Pre-requisites
 
-    apt-get install npm
+We require Node.js and npm to be installed in order to run eva locally.<br/>
 
-NOTE: If you are behind institute proxy, please follow commands listed [here](https://wiki.metakgp.org/w/Institute_proxies#npm).
+nvm (node version manager) is needed for the installation of Node.js and npm. To [install](https://github.com/creationix/nvm/blob/master/README.md#install-script) nvm use curl<br/>
+
+ `curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash`<br/>
+ 
+ or use wget<br/>
+ 
+ `wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash`<br/>
+ 
+The below script clones the nvm repository to `~/.nvm` and adds the source line to your profile (`~/.bash_profile`, `~/.zshrc`, `~/.profile`, or `~/.bashrc`).
+
+`export NVM_DIR="$HOME/.nvm"`<br/>
+`[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm`<br/>
+
+NOTE: If you are behind institute proxy, please set proxy for [nvm](https://wiki.metakgp.org/w/Institute_proxies#nvm).
+
+Now install Node.js LTS (long term support) version (this will also install npm LTS) using<br/>
+
+`nvm install --lts`<br/>
+
+
+
+NOTE: If you are behind institute proxy, please set proxy for [npm](https://wiki.metakgp.org/w/Institute_proxies#npm).
+
+#### Running Eva
 
 Now you can start Eva locally by running:
 

--- a/channel_long_descriptions.json
+++ b/channel_long_descriptions.json
@@ -12,5 +12,8 @@
   "music": "A channel where you can share your musical tastes and the latest videos of your favourite singers!",
   "random": "The channel for everything that doesn't fit anywhere above!",
   "recent-changes": "Changes related to KGP brought to you by our very own Batman!",
-  "tech-help": "All queries to Linux,Ubuntu and Meta-projects are discussed here. Please search well, before asking your questions.(Search here means to look out on Google or StackOverFlow)"
+  "tech-help": "All queries to Linux,Ubuntu and Meta-projects are discussed here. Please search well, before asking your questions.(Search here means to look out on Google or StackOverFlow)",
+  "server": "All MetaKGP server realted queries go here. To begin with, we run a Digital Ocean droplet.",
+  "governance": "The channel where discussions related to the functioning, improvements and maintenances of MetaKGP happen.",
+  "demo-day": "The discussions related to demo-day goes here. It is an initiative of MetaKGP to promote development of personal projects in IIT KGP. Anyone can register, give project demo and stand a chance to win cash prize."
 }

--- a/channel_long_descriptions.json
+++ b/channel_long_descriptions.json
@@ -12,8 +12,8 @@
   "music": "A channel where you can share your musical tastes and the latest videos of your favourite singers!",
   "random": "The channel for everything that doesn't fit anywhere above!",
   "recent-changes": "Changes related to KGP brought to you by our very own Batman!",
-  "tech-help": "All queries to Linux,Ubuntu and Meta-projects are discussed here. Please search well, before asking your questions.(Search here means to look out on Google or StackOverFlow)",
-  "server": "All MetaKGP server realted queries go here. To begin with, we run a Digital Ocean droplet.",
-  "governance": "The channel where discussions related to the functioning, improvements and maintenances of MetaKGP happen.",
-  "demo-day": "The discussions related to demo-day goes here. It is an initiative of MetaKGP to promote development of personal projects in IIT KGP. Anyone can register, give project demo and stand a chance to win cash prize."
+  "tech-help": "All queries regarding Linux, Ubuntu and Meta-projects are discussed here. Please search (google or stackoverflow) well before asking your questions, RTFM and then ask (smart) questions (http://www.catb.org/esr/faqs/smart-questions.html).",
+  "server": "All MetaKGP server related queries go here. To begin with, we run a Digital Ocean droplet (https://wiki.metakgp.org/w/Metakgp:SysAdmin).",
+  "governance": "This is the channel where discussions related to the functioning and maintenance of the Metakgp organization happens.",
+  "demo-day": "Discussions related to demo-day belong here. Demo Day is an initiative by Metakgp to promote development of potentially high-impact projects. Anyone can register and demo their project to the arbiters. Participants also stand a chance to win a cash prize of Rs. 1000."
 }

--- a/scripts/welcome.coffee
+++ b/scripts/welcome.coffee
@@ -18,6 +18,11 @@
 # Author:
 #  nevinvalsaraj
 #  icyflame
+
+
+randNum = (up_lim) ->
+  return (Math.floor(Math.random() * (2 * up_lim)) % up_lim)
+
 welcome_message_1 = [
   "Hi ",
   "Hola ",
@@ -27,19 +32,19 @@ welcome_message_1 = [
 ]
 
 welcome_message_2 = [
-  "! Looks like you're new to MetaKGP slack, welcome.\n",
-  "! Looks like this is your first time at MetaKGP slack, welcome.\n",
-  "! Welcome to MetaKgp!\n",
-]
+  "! Looks like you're new to MetaKGP slack, welcome.",
+  "! Looks like this is your first time at MetaKGP slack, welcome.",
+  "! Welcome to MetaKgp!",
+].join('\n')
 
 welcome_message_3 = [
-  "\nForgot to mention, everyone is waiting for you to say 'hi' in #general",
-  "\nBy the way, why don't you tell everyone a bit about yourself in #general?"
+  "Forgot to mention, everyone is waiting for you to say 'hi' in #general",
+  "By the way, why don't you tell everyone a bit about yourself in #general?"
 ]
 
-welcome_message_4 = " Also, it will be really helpful if you update your Slack profile with real name and contact number.\nEnjoy the stay :)"
+welcome_message_4 = " Also, it will be really helpful if you update your Slack profile with real name and contact number."
 channels_info = [
-  "\n\nThe following is a list of channels and the type of discussions that each channel is designed to contain:",
+  "The following is a list of channels and the type of discussions that each channel is designed to contain:",
   "- #mfqp-source -> Discussions about the mfqp-source project",
   "- #meta-x -> Disussions related to ongoing meta-x projects (naarad, mfqp, mftp, mcmp) and future moonshots",
   "- #book-club -> Read a book that you want to talk about? Want to read a book that someone else talked about? Go here!",
@@ -50,7 +55,7 @@ channels_info = [
   "GitHub: https://github.com/metakgp",
   "Wiki: https://wiki.metakgp.org"
 ].join('\n')
-googleGroupInvite = "\nWe also have a google group where we post all the latest announcements. You can join it by going to https://goo.gl/Uk4Lfl."
+googleGroupInvite = "We also have a google group where we post all the latest announcements. You can join it by going to https://goo.gl/Uk4Lfl."
 channel_descriptions = JSON.parse require("fs").readFileSync("channel_long_descriptions.json")
 sorry_no_information = "Ooops! It seems we don't know anything more about this channel! Sorry, you are a pioneer!"
 
@@ -74,14 +79,14 @@ plugin = (robot) ->
   robot.enter (msg) ->
     if msg.message.room == "general"
 
-      randNum = Math.floor(Math.random() * 10)
-      robot.send {room: msg.message.user.name}, welcome_message_1[randNum % (welcome_message_1.length-1)] + \
-        '@' + msg.message.user.name + welcome_message_2[randNum % \
-          (welcome_message_2.length-1)]
-      robot.send {room: msg.message.user.name}, googleGroupInvite
-      robot.send {room: msg.message.user.name}, channels_info
-      robot.send {room: msg.message.user.name}, welcome_message_3[randNum % \
-            (welcome_message_3.length-1)] + welcome_message_4
+      complete_msg = [
+        welcome_message_1[randNum(welcome_message_1.length-1)] + '@' + msg.message.user.name + welcome_message_2[randNum(welcome_message_2.length-1)],
+        googleGroupInvite,
+        channels_info,
+        welcome_message_3[randNum(welcome_message_3.length-1)] + welcome_message_4
+      ].join('\n')
+      robot.send {room: msg.message.user.name}, complete_msg
+
     else
       robot.send {room: msg.message.user.name}, "Hey #{msg.message.user.name}, You just joined ##{msg.message.room}, here's some information about this channel!"
       more_about_the_channel = sorry_no_information

--- a/scripts/welcome.coffee
+++ b/scripts/welcome.coffee
@@ -22,24 +22,24 @@ welcome_message_1 = [
   "Hi ",
   "Hola ",
   "Hey ",
-  "Hey there, "
+  "Hey there, ",
+  "Yo "
 ]
 
 welcome_message_2 = [
-  "! Looks like you're new here.",
-  "! Looks like this is your first time here.",
-  "! Welcome to MetaKgp!",
+  "! Looks like you're new to MetaKGP slack, welcome.\n",
+  "! Looks like this is your first time at MetaKGP slack, welcome.\n",
+  "! Welcome to MetaKgp!\n",
 ]
 
 welcome_message_3 = [
-  " Why don't you introduce yourself?",
-  " Why don't you tell us a bit about you?"
+  "\nForgot to mention, everyone is waiting for you to say 'hi' in #general",
+  "\nBy the way, why don't you tell everyone a bit about yourself in #general?"
 ]
 
-welcome_message_4 = " Also, it will be very helpful if you would update your Slack profile with your real name and contact number."
+welcome_message_4 = " Also, it will be really helpful if you update your Slack profile with real name and contact number.\nEnjoy the stay :)"
 channels_info = [
-  "Hello, welcome to Metakgp's Slack!",
-  "The following is a list of channels and the type of discussions  that each channel is designed to contain:",
+  "\n\nThe following is a list of channels and the type of discussions that each channel is designed to contain:",
   "- #mfqp-source -> Discussions about the mfqp-source project",
   "- #meta-x -> Disussions related to ongoing meta-x projects (naarad, mfqp, mftp, mcmp) and future moonshots",
   "- #book-club -> Read a book that you want to talk about? Want to read a book that someone else talked about? Go here!",
@@ -50,7 +50,7 @@ channels_info = [
   "GitHub: https://github.com/metakgp",
   "Wiki: https://wiki.metakgp.org"
 ].join('\n')
-googleGroupInvite = "We also have a google group where we post all the latest announcements. You can join it by going to https://goo.gl/Uk4Lfl ."
+googleGroupInvite = "\nWe also have a google group where we post all the latest announcements. You can join it by going to https://goo.gl/Uk4Lfl."
 channel_descriptions = JSON.parse require("fs").readFileSync("channel_long_descriptions.json")
 sorry_no_information = "Ooops! It seems we don't know anything more about this channel! Sorry, you are a pioneer!"
 
@@ -73,12 +73,14 @@ plugin = (robot) ->
 
   robot.enter (msg) ->
     if msg.message.room == "general"
+
+      randNum = Math.floor(Math.random() * 10)
+      robot.send {room: msg.message.user.name}, welcome_message_1[randNum % (welcome_message_1.length-1)] + \
+        '@' + msg.message.user.name + welcome_message_2[randNum % \
+          (welcome_message_2.length-1)]
       robot.send {room: msg.message.user.name}, googleGroupInvite
       robot.send {room: msg.message.user.name}, channels_info
-      randNum = Math.floor(Math.random() * 10)
-      msg.send welcome_message_1[randNum % (welcome_message_1.length-1)] + \
-        '@' + msg.message.user.name + welcome_message_2[randNum % \
-          (welcome_message_2.length-1)] + welcome_message_3[randNum % \
+      robot.send {room: msg.message.user.name}, welcome_message_3[randNum % \
             (welcome_message_3.length-1)] + welcome_message_4
     else
       robot.send {room: msg.message.user.name}, "Hey #{msg.message.user.name}, You just joined ##{msg.message.room}, here's some information about this channel!"


### PR DESCRIPTION
1. Restructure joining message
    Below is a sample of the new joining message:

![screenshot from 2018-03-08 18-49-57](https://user-images.githubusercontent.com/32812320/37153150-ce986eee-2301-11e8-97d2-bdc5d6e0c75b.png)

2. Shift posting of joining message from general to user's channel.
    Now the message is only sent to user's private channel and not to "#general".
3. Update channel information.
    Concerns #10 
    Added for server, governance and demo-day.
4. Update README.md with npm installation instructions
    Reference: [freecodecamp](https://forum.freecodecamp.org/t/npm-behind-a-proxy-server/19386)
    It wasn't working without npm and I had to look over stackoverflow to know it had to be installed.  
    Hence, it should be present in the instructions.
                           