### PR TITLE
Reduce frequency of sending issues; from everyday to every Saturday

### DIFF
--- a/scripts/send_issues.coffee
+++ b/scripts/send_issues.coffee
@@ -99,10 +99,10 @@ send_issue_plugin = (robot) ->
     git_msg(msg, robot, true, true)
   
   """
-  Sends a github issue every day to random at 10 AM IST
+  Sends a github issue every saturday to random at 10 AM IST
   """
   HubotCron = require('hubot-cronjob')
-  pattern = "0 10 * * *"
+  pattern = "0 10 * * SAT"
   timezone = "Asia/Kolkata"
   fn = () ->
     git_msg(null, robot, false, true)


### PR DESCRIPTION
Asked by @icyflame, the frequency of sending issues is too much and hence, the effectiveness of the message is hampered. To overcome this, we will be testing if it's more effective to send issues once a week only. 

Saturday has been chosen since if someone want to work on the issue posted, they'll have saturday and sunday to work.

Change severity: trivial
